### PR TITLE
fix: use /api/v3 gateway paths in WaveSpeedClient

### DIFF
--- a/py/wavespeed_api/client.py
+++ b/py/wavespeed_api/client.py
@@ -142,7 +142,7 @@ class WaveSpeedClient:
         if not request_id:
             raise Exception("No valid task ID provided")
         # Use 30s timeout for status checks - these should be quick
-        return self.get(f"/api/v2/predictions/{request_id}/result", timeout=30)
+        return self.get(f"/api/v3/predictions/{request_id}/result", timeout=30)
 
     def wait_for_task(self, request_id, polling_interval=5, timeout=None):
         """
@@ -222,7 +222,7 @@ class WaveSpeedClient:
         Returns:
             dict: API response containing the uploaded file information
         """
-        url = f"{self.BASE_URL}/api/v2/media/upload/binary"
+        url = f"{self.BASE_URL}/api/v3/media/upload/binary"
         buffered = io.BytesIO()
         image.save(buffered, format="PNG")
         buffered.seek(0)
@@ -249,7 +249,7 @@ class WaveSpeedClient:
         Args:
             video_path (str): Path to the video to be uploaded
         """
-        url = f"{self.BASE_URL}/api/v2/media/upload/binary"
+        url = f"{self.BASE_URL}/api/v3/media/upload/binary"
         with open(file_path, "rb") as file:
             file_name = ""
             if "video" in file_type:

--- a/py/wavespeed_api_endpoints.py
+++ b/py/wavespeed_api_endpoints.py
@@ -494,7 +494,7 @@ def should_disable_parameter(prop):
 async def upload_file_or_tensor(request):
     """
     Upload file to WaveSpeed cloud server and return URL
-    Uses WaveSpeed's /api/v2/media/upload/binary endpoint
+    Uses WaveSpeed's /api/v3/media/upload/binary endpoint
     """
     try:
         # Get effective API key (runtime or persistent config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wavespeed-comfyui"
 description = "Universal AI generation plugin for ComfyUI - Access 600+ models across 25+ categories (text-to-image, image-to-video, text-to-audio, etc.) through WaveSpeed AI API. One node, all modalities."
-version = "2.0.0"
+version = "2.0.1"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Why
`py/wavespeed_api/client.py` (imported by the registered `wavespeed_predictor` node) still called the legacy `/api/v2` gateway for prediction-result polling and binary media upload. New orgs (id ≥ 500000) are now blocked from v1/v2 by the api-server legacy gate, so these calls would **403 for new accounts**.

## What
- `client.py`: `/api/v2/predictions/{id}/result` and `/api/v2/media/upload/binary` (×2) → `/api/v3/...`
- Fixed a stale `/api/v2` docstring in `wavespeed_api_endpoints.py`
- Bumped `2.0.0` → `2.0.1`

The v3 routes use the identical `{code,message,data}` envelope (client already checks `code != 200`) and both exist under v3, so this is path-only. The other node modules were already on v3.

## Verification
`python3 -m py_compile` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)